### PR TITLE
migrate to adaptopenjdk API v3

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -18,6 +18,7 @@
     "Vuillamy",
     "aarch",
     "adoptopenjdk",
+    "adoptium",
     "dotenv",
     "eslintcache",
     "fileurl",

--- a/lib/install.js
+++ b/lib/install.js
@@ -71,7 +71,6 @@ function verify (file) {
 function move (file) {
   return new Promise((resolve, reject) => {
     const newFile = path.join(path.dirname(require.main.filename), file.split(path.sep).slice(-1)[0])
-
     fs.copyFile(file, newFile, err => {
       if (err) reject(err)
 
@@ -173,9 +172,12 @@ function extract (file) {
  *   })
  */
 function install (version = 8, options = {}) {
-  const { openjdk_impl = 'hotspot', release = 'latest', type = 'jre' } = options
-  options = { ...options, openjdk_impl, release, type }
-  let url = 'https://api.adoptopenjdk.net/v2/info/releases/openjdk' + version + '?'
+  const { openjdk_impl = 'hotspot', release = 'latest', type = 'jre', heap_size = 'normal', vendor = 'eclipse' } = options
+  options = { ...options, openjdk_impl, release, type, heap_size, vendor }
+
+  let version_path = (options.release === 'latest')
+    ? 'latest/' + version + '/ga'
+    : 'version/' + options.release
 
   if (!options.os) {
     switch (process.platform) {
@@ -204,13 +206,20 @@ function install (version = 8, options = {}) {
     else return Promise.reject(new Error('Unsupported architecture'))
   }
 
-  Object.keys(options).forEach(key => { url += key + '=' + options[key] + '&' })
+  let url = 'https://api.adoptium.net/v3/binary/'
+    + version_path + '/'
+    + options.os + '/'
+    + options.arch + '/'
+    + options.type + '/'
+    + options.openjdk_impl + '/'
+    + options.heap_size + '/'
+    + options.vendor
 
   const tmpdir = path.join(os.tmpdir(), 'njre')
 
-  return fetch(url)
-    .then(response => response.json())
-    .then(json => downloadAll(tmpdir, json.binaries[0].binary_link))
+  return fetch(url, {redirect: 'manual'})
+    .then(response => response.headers.get('Location'))
+    .then(location => downloadAll(tmpdir, location))
     .then(verify)
     .then(move)
     .then(extract)

--- a/lib/install.js
+++ b/lib/install.js
@@ -141,6 +141,19 @@ function extract (file) {
 }
 
 /**
+ * The API will decide if it needs to redirect from api.adoptopenjdk.net to
+ * api.adoptium.net before finally redirecting to the binary. This function
+ * handles the initial redirection if needed, otherwise it just returns the
+ * location url for the binary.
+**/
+function followToAdoptium (location) {
+  if (/api.adoptium.net/g.test(location)) {
+    return fetch(location, {redirect: 'manual'})
+      .then(response => response.headers.get('Location'))
+  } else return location
+}
+
+/**
  * Installs a JRE copy for the app
  * @param {number} [version = 8] - Java Version (`8`/`9`/`10`/`11`/`12`)
  * @param {object} [options] - Installation Options
@@ -150,6 +163,7 @@ function extract (file) {
  * @param {string} [options.release = latest] - Release
  * @param {string} [options.type = jre] - Binary Type (`jre`/`jdk`)
  * @param {string} [options.heap_size] - Heap Size (`normal`/`large`)
+ * @param {string} [options.vendor] - defaults to eclipse (`eclipse`/`adoptopenjdk`)
  * @return Promise<string> - Resolves to the installation directory or rejects an error
  * @example
  * const njre = require('njre')
@@ -173,8 +187,20 @@ function extract (file) {
  *   })
  */
 function install (version = 8, options = {}) {
-  const { openjdk_impl = 'hotspot', release = 'latest', type = 'jre', heap_size = 'normal', vendor = 'eclipse' } = options
+  const {
+    openjdk_impl = 'hotspot',
+    release = 'latest',
+    type = 'jre',
+    heap_size = 'normal',
+    vendor = 'adoptopenjdk'
+  } = options
+
   options = { ...options, openjdk_impl, release, type, heap_size, vendor }
+
+  let endpoint = null
+  if (options.vendor === 'adoptopenjdk') endpoint = 'api.adoptopenjdk.net'
+  else if (options.vendor === 'eclipse') endpoint = 'api.adoptium.net'
+  else return Promise.reject(new Error('Unsupported vendor. Use adoptopenjdk (default) or eclipse'))
 
   let version_path = (options.release === 'latest')
     ? 'latest/' + version + '/ga'
@@ -207,7 +233,7 @@ function install (version = 8, options = {}) {
     else return Promise.reject(new Error('Unsupported architecture'))
   }
 
-  let url = 'https://api.adoptium.net/v3/binary/'
+  let url = 'https://' + endpoint + '/v3/binary/'
     + version_path + '/'
     + options.os + '/'
     + options.arch + '/'
@@ -220,6 +246,7 @@ function install (version = 8, options = {}) {
 
   return fetch(url, {redirect: 'manual'})
     .then(response => response.headers.get('Location'))
+    .then(location => followToAdoptium(location))
     .then(location => downloadAll(tmpdir, location))
     .then(verify)
     .then(move)

--- a/lib/install.js
+++ b/lib/install.js
@@ -148,7 +148,7 @@ function extract (file) {
 **/
 function followToAdoptium (location) {
   if (/api.adoptium.net/g.test(location)) {
-    return fetch(location, {redirect: 'manual'})
+    return fetch(location, { redirect: 'manual' })
       .then(response => response.headers.get('Location'))
   } else return location
 }
@@ -202,7 +202,7 @@ function install (version = 8, options = {}) {
   else if (options.vendor === 'eclipse') endpoint = 'api.adoptium.net'
   else return Promise.reject(new Error('Unsupported vendor. Use adoptopenjdk (default) or eclipse'))
 
-  let version_path = (options.release === 'latest')
+  const versionPath = (options.release === 'latest')
     ? 'latest/' + version + '/ga'
     : 'version/' + options.release
 
@@ -233,18 +233,18 @@ function install (version = 8, options = {}) {
     else return Promise.reject(new Error('Unsupported architecture'))
   }
 
-  let url = 'https://' + endpoint + '/v3/binary/'
-    + version_path + '/'
-    + options.os + '/'
-    + options.arch + '/'
-    + options.type + '/'
-    + options.openjdk_impl + '/'
-    + options.heap_size + '/'
-    + options.vendor
+  const url = 'https://' + endpoint + '/v3/binary/' +
+    versionPath + '/' +
+    options.os + '/' +
+    options.arch + '/' +
+    options.type + '/' +
+    options.openjdk_impl + '/' +
+    options.heap_size + '/' +
+    options.vendor
 
   const tmpdir = path.join(os.tmpdir(), 'njre')
 
-  return fetch(url, {redirect: 'manual'})
+  return fetch(url, { redirect: 'manual' })
     .then(response => response.headers.get('Location'))
     .then(location => followToAdoptium(location))
     .then(location => downloadAll(tmpdir, location))

--- a/lib/install.js
+++ b/lib/install.js
@@ -163,7 +163,7 @@ function followToAdoptium (location) {
  * @param {string} [options.release = latest] - Release
  * @param {string} [options.type = jre] - Binary Type (`jre`/`jdk`)
  * @param {string} [options.heap_size] - Heap Size (`normal`/`large`)
- * @param {string} [options.vendor] - defaults to eclipse (`eclipse`/`adoptopenjdk`)
+ * @param {string} [options.vendor] - defaults to adoptopenjdk (`adoptopenjdk`/`eclipse`)
  * @return Promise<string> - Resolves to the installation directory or rejects an error
  * @example
  * const njre = require('njre')

--- a/lib/install.js
+++ b/lib/install.js
@@ -71,6 +71,7 @@ function verify (file) {
 function move (file) {
   return new Promise((resolve, reject) => {
     const newFile = path.join(path.dirname(require.main.filename), file.split(path.sep).slice(-1)[0])
+
     fs.copyFile(file, newFile, err => {
       if (err) reject(err)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "javaw",
     "jdk",
     "openjdk",
-    "adoptopenjdk"
+    "adoptopenjdk",
+    "adoptium"
   ],
   "homepage": "https://github.com/raftario/njre",
   "bugs": "https://github.com/raftario/njre/issues",

--- a/tests/test.js
+++ b/tests/test.js
@@ -7,7 +7,11 @@ describe('Install', () => {
     return njre.install()
   }).timeout(100000)
 
-  it('should install JRE with custom options without throwing an error', () => {
-    return njre.install(11, { os: 'aix', arch: 'ppc64', openjdk_impl: 'openj9' })
+  it('should install JDK with custom options without throwing an error', () => {
+    return njre.install(11, { os: 'aix', arch: 'ppc64', openjdk_impl: 'hotspot', type: 'jdk' })
+  }).timeout(100000)
+
+  it('should install JDK with custom release without throwing an error', () => {
+    return njre.install(null, { release: 'jdk-21+34-ea-beta' })
   }).timeout(100000)
 })

--- a/tests/test.js
+++ b/tests/test.js
@@ -16,7 +16,7 @@ describe('Install', () => {
   }).timeout(100000)
 
   it('should install JRE 14 from AdoptOpenJdk without throwing an error', () => {
-    return njre.install(14, { os: 'linux'})
+    return njre.install(14, { os: 'linux' })
   }).timeout(100000)
 
   it('should install JRE 20 from Eclipse Foundation without throwing an error', () => {

--- a/tests/test.js
+++ b/tests/test.js
@@ -7,11 +7,19 @@ describe('Install', () => {
     return njre.install()
   }).timeout(100000)
 
-  it('should install JDK with custom options without throwing an error', () => {
-    return njre.install(11, { os: 'aix', arch: 'ppc64', openjdk_impl: 'hotspot', type: 'jdk' })
+  it('should install JRE with custom options without throwing an error', () => {
+    return njre.install(11, { os: 'aix', arch: 'ppc64', openjdk_impl: 'openj9' })
   }).timeout(100000)
 
   it('should install JDK with custom release without throwing an error', () => {
     return njre.install(null, { release: 'jdk-21+34-ea-beta' })
+  }).timeout(100000)
+
+  it('should install JRE 14 from AdoptOpenJdk without throwing an error', () => {
+    return njre.install(14, { os: 'linux'})
+  }).timeout(100000)
+
+  it('should install JRE 20 from Eclipse Foundation without throwing an error', () => {
+    return njre.install(20, { vendor: 'eclipse' })
   }).timeout(100000)
 })


### PR DESCRIPTION
Migrate to AdaptOpenJdk API v3. AdaptOpenJdk is migrating to Adoptium but AOJ still has releases not found in Adoptium so AOJ is still the default endpoint here.

Fixes #15 
