### PR TITLE
support aarch64 arch (apple silicon)

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: MegaLinter reports

--- a/lib/install.js
+++ b/lib/install.js
@@ -233,8 +233,9 @@ function install(version = 8, options = {}) {
   if (!options.arch) {
     if (/^ppc64|s390x|x32|x64$/g.test(process.arch))
       options.arch = process.arch;
-    else if (process.arch === "ia32") options.arch = "x32";
-    else return Promise.reject(new Error("Unsupported architecture"));
+      else if (process.arch === "ia32") options.arch = "x32";
+      else if (process.arch === "arm64") options.arch = "aarch64";
+      else return Promise.reject(new Error("Unsupported architecture"));
   }
 
   const url =


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #
https://github.com/nvuillam/njre/issues/56
and eventually:
https://github.com/nvuillam/npm-groovy-lint/issues/296
https://github.com/nvuillam/vscode-groovy-lint/issues/163

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

add `arm64` arch (referenced as `aarch64` on adoptium.net) to the list of supported architecture.

I don't know how to test it but it should work and not impact other architectures detection. I have access to apple silicon mac so I should be able to test when it will be used by `java-caller` or `npm-groovy-lint`

example of links you get when you browse adoptium 
from apple silicon mac
`https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz`
from intel mac
`https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz`

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
