### PR TITLE
Fix Mac bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add your updates here !
 
+## [v1.2.1] - 2024-05-08
+
+- Fix bug always installing Java 11 on Mac
+- Block combination Java 8 + Darwin (Mac)
+
 ## [v1.2.0] - 2024-05-08
 
 - Fix issue with Mac with default values

--- a/lib/install.js
+++ b/lib/install.js
@@ -197,9 +197,13 @@ function install(version = 8, options = {}) {
 
   options = { ...options, openjdk_impl, release, type, heap_size, vendor };
 
-  // Java 8 not supported by Api
-  if (os.platform() === "darwin") {
+  // Java 8 not supported by Api, set default value to Java 11
+  if (os.platform() === "darwin" && version === 8) {
     version = 11;
+  }
+  // Block if use tries impossible combination
+  if (options.release === "8" && os.platform() === "darwin") {
+    throw new Error("Java 8 is not available in darwin platform (Mac)")
   }
 
   let endpoint = null;


### PR DESCRIPTION
- Fix bug always installing Java 11 on Mac
- Block combination Java 8 + Darwin (Mac)
