### PR TITLE
fix: typefix for `installPath` param annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased] (beta, main branch content)
 
+## [v1.4.1] - 2025-02-06
+
+- fix: Add `installPath` parameter type annotation.
+
 ## [v1.4.0] - 2024-08-30
 
 - Allow to force an installation path for java using option `installPath`

--- a/lib/install.js
+++ b/lib/install.js
@@ -164,6 +164,7 @@ function followToAdoptium(location) {
  * @param {string} [options.type = jre] - Binary Type (`jre`/`jdk`)
  * @param {string} [options.heap_size] - Heap Size (`normal`/`large`)
  * @param {string} [options.vendor] - defaults to adoptopenjdk (`adoptopenjdk`/`eclipse`)
+ * @param {string} [options.installPath] - Where to install java (default process.cwd())
  * @return Promise<string> - Resolves to the installation directory or rejects an error
  * @example
  * const njre = require('njre')


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

It pops the type hint error when I set the `installPath`.

![image](https://github.com/user-attachments/assets/d2f50e31-920b-4426-a192-3e96764d30d5)

That's because the type annotation for `installPath` is ignored by mistake. So I add `installPath` parameter type annotation in 167th line.

```diff
......
 * @param {string} [options.type = jre] - Binary Type (`jre`/`jdk`)
 * @param {string} [options.heap_size] - Heap Size (`normal`/`large`)
 * @param {string} [options.vendor] - defaults to adoptopenjdk (`adoptopenjdk`/`eclipse`)
+* @param {string} [options.installPath] - Where to install java (default process.cwd())
 * @return Promise<string> - Resolves to the installation directory or rejects an error
......
```

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
