### PR TITLE
Fix release workflow: drop yarn install before npm publish

### DIFF
--- a/.github/workflows/deploy-RELEASE.yml
+++ b/.github/workflows/deploy-RELEASE.yml
@@ -38,5 +38,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           # Defaults to the user or organization that owns the workflow file
           scope: "nvuillam"
-      - run: yarn
-      - run: yarn config set network-timeout 300000 && npm publish
+      # No install step: the package has no build/prepack scripts, npm publish
+      # only packs package.json + lib/*.js. It also avoids `yarn` failing on
+      # the ${NODE_AUTH_TOKEN} placeholder setup-node writes to .npmrc, which
+      # is never set here (publish auth uses npm Trusted Publishers / OIDC).
+      - run: npm publish


### PR DESCRIPTION
The v3.0.0 release job failed at the `yarn` step:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

`actions/setup-node` with `registry-url` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. Yarn 1 hard-errors when that variable is unset (npm only warns) — and it is never set in this workflow because publishing uses npm Trusted Publishers (OIDC), not a token.

Fix: remove the `yarn` install step entirely. It is unnecessary — the package has no build/prepare/prepack scripts, and `npm publish` only packs `package.json` + `lib/*.js`. The `yarn config set network-timeout` was only there for the removed install.

After merging, the v3.0.0 release needs to be re-created (delete + create release/tag pointing at a commit that contains this fix) so the release event runs the fixed workflow — release workflows execute the workflow file as of the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)